### PR TITLE
Fix require()s to support browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,6 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 var path = require("path"),
-    bcrypt = require(path.join(__dirname, "dist", "bcrypt.js"));
+    bcrypt = require("./dist/bcrypt.js");
 
 module.exports = bcrypt;


### PR DESCRIPTION
Modify the `require()` call in index.js to use a static relative path,
instead of building a dynamic absolute path using `path.join()`.

This change is necessary to make the module work with browserify,
since browserify does not support dynamic paths in `require()`.

This patch fixes the problem introduced by 0e974f00 in v1.0.1.

/to @dcodeIO could you please merge and release ASAP?

If you still prefer to use `path.join` instead of relative paths, then there is another possible fix - add a `browser` entry to the `package.json` to tell browserify to use `dist/bcrypt.js` instead of `index.js` as the package entry file.

Another option is to drop the `index.js` file and add `"main": "dist/bcrypt.js"` to `package.json`.

There are many possible solutions and I don't really care which one will be used at the end, as long as we can get a fixed version in the npm soon.
