### PR TITLE
update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,7 @@
         "bcrypt": "latest",
         "utfx": "~1"
     },
-    "licenses" : [
-        {
-            "type" : "New-BSD, MIT",
-            "url" : "https://raw.githubusercontent.com/dcodeIO/bcrypt.js/master/LICENSE"
-        }
-    ],
+    "license" : "MIT",
     "scripts": {
         "test": "node node_modules/testjs/bin/testjs",
         "build": "node scripts/build.js",


### PR DESCRIPTION
License objects and a "licenses" property containing an array of license objects are now deprecated from [npm@v2.10+](https://github.com/npm/npm/blob/master/CHANGELOG.md#v2100-2015-05-8)

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/