### PR TITLE
Expand the range of allowed rounds in a hash

### DIFF
--- a/src/bcrypt.js
+++ b/src/bcrypt.js
@@ -74,8 +74,8 @@ bcrypt.genSaltSync = function(rounds, seed_length) {
         rounds = GENSALT_DEFAULT_LOG2_ROUNDS;
     else if (typeof rounds !== 'number')
         throw Error("Illegal arguments: "+(typeof rounds)+", "+(typeof seed_length));
-    if (rounds < 4 || rounds > 31)
-        throw Error("Illegal number of rounds (4-31): "+rounds);
+    if (rounds < 0 || rounds > 31)
+        throw Error("Illegal number of rounds (0-31): "+rounds);
     var salt = [];
     salt.push("$2a$");
     if (rounds < 10)

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -33,6 +33,12 @@ module.exports = {
             bcrypt.hashSync("hello", 10);
         });
         test.notEqual(bcrypt.hashSync("hello", 10), bcrypt.hashSync("hello", 10));
+        test.throws(function() {
+            bcrypt.hashSync("hello", -1);
+        });
+        test.throws(function() {
+            bcrypt.hashSync("hello", 32);
+        });
         test.done();
     },
     


### PR DESCRIPTION
Other bcrypt libraries allows 0-31 rounds while generating a hash; introduce the same limits to improve conformance.

Refs #19.