### PR TITLE
Added externs to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ debug.log
 doco/
 tests/bench.js
 *.png
+externs


### PR DESCRIPTION
The npm package does not need externs as it is needed only for closure compiler. Added it in .npmignore since bcryptjs overrides  global module and process in WebStorm IDE.