### PR TITLE
fix: Always yield to event loop before nextTick for async versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,19 +326,17 @@ export function truncates(password) {
 }
 
 /**
- * Continues with the callback on the next tick.
+ * Continues with the callback after yielding to the event loop.
  * @function
  * @param {function(...[*])} callback Callback to execute
  * @inner
  */
 var nextTick =
-  typeof process !== "undefined" &&
-  process &&
-  typeof process.nextTick === "function"
-    ? typeof setImmediate === "function"
-      ? setImmediate
-      : process.nextTick
-    : setTimeout;
+  typeof setImmediate === "function"
+    ? setImmediate
+    : typeof scheduler === "object" && typeof scheduler.postTask === "function"
+      ? scheduler.postTask.bind(scheduler)
+      : setTimeout;
 
 /** Calculates the byte length of a string encoded as UTF8. */
 function utf8Length(string) {


### PR DESCRIPTION
Fixes https://github.com/dcodeIO/bcrypt.js/issues/80, which is still an issue in environments with `process.nextTick` but no `setImmediate` (e.g. browser with polyfilled Node `process`).

New order of preference as follows:

```diff
  1. setImmediate
- 2. process.nextTick
+ 2. scheduler.postTask
  3. setTimeout
```

[`scheduler.postTask`](https://developer.mozilla.org/en-US/docs/Web/API/Scheduler/postTask) [seems to be](https://nolanlawson.com/2025/08/) the standardized browser API with the closest performance characteristics and ergonomics to `setImmediate`, but it's not yet implemented in all browsers (notably Safari support is still missing).