### PR TITLE
fix #167: Validate rounds format to prevent NaN bypass

### DIFF
--- a/index.js
+++ b/index.js
@@ -1075,9 +1075,17 @@ function _hash(password, salt, callback, progressCallback) {
       return;
     } else throw err;
   }
-  var r1 = parseInt(salt.substring(offset, offset + 1), 10) * 10,
-    r2 = parseInt(salt.substring(offset + 1, offset + 2), 10),
-    rounds = r1 + r2,
+  // Validate rounds format before parsing
+  var roundsStr = salt.substring(offset, offset + 2);
+  if (!/^\d{2}$/.test(roundsStr)) {
+    err = Error("Invalid rounds: " + roundsStr);
+    if (callback) {
+      nextTick(callback.bind(this, err));
+      return;
+    } else throw err;
+  }
+
+  var rounds = parseInt(roundsStr, 10),
     real_salt = salt.substring(offset + 3, offset + 25);
   password += minor >= "a" ? "\x00" : "";
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -237,13 +237,11 @@ const tests = [
   // ===== INVALID ROUNDS VALIDATION =====
 
   function invalidRoundsNaNProducesWeakHash(done) {
-    // Demonstrates the vulnerability: without validation, NaN rounds
+    // Demonstrates vulnerability fix: without validation, NaN rounds
     // produces a hash with "NaN" in the rounds field and only 1 bcrypt
     // iteration (1 << NaN = 1), making it trivially crackable.
     var malformedSalt = "$2b$xx$" + ".".repeat(22);
-    var hash = bcrypt.hashSync("password", malformedSalt);
-    // The hash contains "NaN" proving parseInt produced NaN
-    assert(!hash.includes("$NaN$"), "Expected hash to NOT contain $NaN$");
+    assert.throws(() => bcrypt.hashSync("password", malformedSalt), /Invalid/);
     done();
   },
 
@@ -272,6 +270,39 @@ const tests = [
     // parseInt("1") * 10 + parseInt("x") = 10 + NaN = NaN
     var malformedSalt = "$2b$1x$" + ".".repeat(22);
     assert.throws(() => bcrypt.hashSync("password", malformedSalt), /Invalid/);
+    done();
+  },
+
+  function validRoundsLeadingZero(done) {
+    // Zero-padded rounds like "04" must be accepted.
+    // bcrypt uses 2-digit zero-padded rounds (04-31).
+    var salt = bcrypt.genSaltSync(4);
+    assert(salt.startsWith("$2b$04$"), "Expected salt to start with $2b$04$");
+    var hash = bcrypt.hashSync("password", salt);
+    assert(hash.startsWith("$2b$04$"), "Expected hash to start with $2b$04$");
+    assert(bcrypt.compareSync("password", hash));
+    done();
+  },
+
+  function invalidRoundsZero(done) {
+    // Rounds "00" is syntactically valid but outside allowed range (4-31).
+    // Must be rejected to prevent weak hashes.
+    var zeroRoundsSalt = "$2b$00$" + ".".repeat(22);
+    assert.throws(
+      () => bcrypt.hashSync("password", zeroRoundsSalt),
+      /Illegal number of rounds/,
+    );
+    done();
+  },
+
+  function invalidRounds32(done) {
+    // Rounds "00" is syntactically valid but outside allowed range (4-31).
+    // Must be rejected to prevent weak hashes.
+    var zeroRoundsSalt = "$2b$32$" + ".".repeat(22);
+    assert.throws(
+      () => bcrypt.hashSync("password", zeroRoundsSalt),
+      /Illegal number of rounds/,
+    );
     done();
   },
 ];

--- a/tests/index.js
+++ b/tests/index.js
@@ -233,6 +233,47 @@ const tests = [
     var umd = require("../umd/index.js");
     umd.genSalt().then(done);
   },
+
+  // ===== INVALID ROUNDS VALIDATION =====
+
+  function invalidRoundsNaNProducesWeakHash(done) {
+    // Demonstrates the vulnerability: without validation, NaN rounds
+    // produces a hash with "NaN" in the rounds field and only 1 bcrypt
+    // iteration (1 << NaN = 1), making it trivially crackable.
+    var malformedSalt = "$2b$xx$" + ".".repeat(22);
+    var hash = bcrypt.hashSync("password", malformedSalt);
+    // The hash contains "NaN" proving parseInt produced NaN
+    assert(!hash.includes("$NaN$"), "Expected hash to NOT contain $NaN$");
+    done();
+  },
+
+  function invalidRoundsNaN(done) {
+    // Non-numeric round values like "xx" must be rejected to prevent
+    // from crafting salts that bypass bcrypt's work factor.
+    // Without this check, parseInt returns NaN which reduces rounds to 1.
+    var malformedSalt = "$2b$xx$" + ".".repeat(22);
+    assert.throws(() => bcrypt.hashSync("password", malformedSalt), /Invalid/);
+    done();
+  },
+
+  function invalidRoundsNaNAsync(done) {
+    // Async version: malformed rounds must error via callback, not
+    // silently produce a weak hash that's trivially crackable.
+    var malformedSalt = "$2b$xx$" + ".".repeat(22);
+    bcrypt.hash("password", malformedSalt, function (err) {
+      assert(err);
+      assert(/Invalid/.test(err.message));
+      done();
+    });
+  },
+
+  function invalidRoundsPartialNaN(done) {
+    // Even partial non-numeric rounds (e.g., "1x") must be rejected.
+    // parseInt("1") * 10 + parseInt("x") = 10 + NaN = NaN
+    var malformedSalt = "$2b$1x$" + ".".repeat(22);
+    assert.throws(() => bcrypt.hashSync("password", malformedSalt), /Invalid/);
+    done();
+  },
 ];
 
 function next() {


### PR DESCRIPTION
Non-numeric characters in the rounds position (e.g., `$2b$xx$...`) causes parseInt to return NaN, which bypasses security validation and reduced bcrypt to a single round.

Fixes dcodeIO/bcrypt.js#167

### Location

`index.js` lines 1078-1080:

```javascript
var r1 = parseInt(salt.substring(offset, offset + 1), 10) * 10,
    r2 = parseInt(salt.substring(offset + 1, offset + 2), 10),
    rounds = r1 + r2,
```

### The Bug

When non-numeric characters are in the rounds position, `parseInt` returns `NaN`:

- `rounds = NaN + NaN = NaN`
- Line 948: `if (rounds < 4 || rounds > 31)` → **PASSES** (NaN comparisons are false)
- Line 964: `rounds = (1 << rounds) >>> 0` → `1 << NaN` = `1 << 0` = **1 round only!**

Red tests added to demonstrate issue:

- invalidRoundsNaNProducesWeakHash: hash contains "$NaN$"
- invalidRoundsNaN: fully non-numeric rounds "xx"
- invalidRoundsNaNAsync: async version via callback
- invalidRoundsPartialNaN: partial non-numeric "1x"

### The Fix

The fix validates that rounds contains exactly 2 digits before parsing, rejecting malformed salts with a clear error message.

### Severity: LOW

In most real-world scenarios, salts come from genSalt() which always produces valid output. The malformed salt would have to come from:

- A buggy application
- Corrupted data
- Deliberately malicious input to compare()

The real value of this fix is:

- Defense in depth - reject invalid input rather than silently degrading
- Fail loudly - better to throw than produce a weak hash
- Correctness - a crypto library should validate all inputs
